### PR TITLE
odroid-c1: Mark as discontinued

### DIFF
--- a/odroid-c1.coffee
+++ b/odroid-c1.coffee
@@ -7,7 +7,7 @@ module.exports =
 	aliases: [ 'odroid-c1' ]
 	name: 'ODROID-C1+'
 	arch: 'armv7hf'
-	state: 'released'
+	state: 'discontinued'
 	private: false
 
 	instructions: commonImg.instructions


### PR DESCRIPTION
This device is no longer supported by the manufacturer and it is stuck
on a v3.10 kernel that does not support overlay2 and cannot build for
newer meta-balena versions.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>